### PR TITLE
Export isClockwise

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,6 +3,7 @@ declare type Point = {
     y: number;
 };
 declare type Contour = Point[];
+export declare function isClockwise(polygon: Contour): boolean;
 /**
  * Removes holes from polygon by merging them with non-hole.
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.convexPartition = exports.triangulate = exports.removeHoles = void 0;
+exports.convexPartition = exports.triangulate = exports.removeHoles = exports.isClockwise = void 0;
 // Signed area.
 function area(a, b, c) {
     return (b.y - a.y) * (c.x - b.x) - (b.x - a.x) * (c.y - b.y);
@@ -54,6 +54,7 @@ function isClockwise(polygon) {
     }
     return sum > 0;
 }
+exports.isClockwise = isClockwise;
 /**
  * Removes holes from polygon by merging them with non-hole.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ function intersects(p11: Point, p12: Point, p21: Point, p22: Point) {
     return !(dot11 * dot12 > 0 || dot21 * dot22 > 0);
 }
 
-function isClockwise(polygon: Contour) {
+export function isClockwise(polygon: Contour) {
     let sum = 0;
     for (let i = 0, len = polygon.length; i < len; ++i) {
         const p1 = polygon[i];


### PR DESCRIPTION
Thanks for making this library! It's really useful for situations where one needs convex polygon partitioning without Steiner points.

This PR exports the `isClockwise` function, which is useful for partitioning polygons when one doesn't already know the orientation:
```javascript
const contour = [...something];
if (isClockwise(contour)) {
  contour.reverse();
}
const convexPolygons = convexPartition(contour);
```
This is in a similar spirit to the `makeCCW` function available in the [poly-decomp.js](https://www.npmjs.com/package/poly-decomp/v/0.3.0#basic-usage) library.